### PR TITLE
Fix write logic in SP model

### DIFF
--- a/test/au/spsram_256x256.au
+++ b/test/au/spsram_256x256.au
@@ -5008,7 +5008,7 @@ module spsram_256x256
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];

--- a/test/au/spsram_256x32.au
+++ b/test/au/spsram_256x32.au
@@ -867,7 +867,7 @@ module spsram_256x32
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];

--- a/test/au/spsram_256x32_h.au
+++ b/test/au/spsram_256x32_h.au
@@ -874,7 +874,7 @@ module spsram_256x32_h
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];

--- a/utils/single_port_ram_verilog_exporter.py
+++ b/utils/single_port_ram_verilog_exporter.py
@@ -60,7 +60,7 @@ class SinglePortRAMVerilogExporter(VerilogExporter):
         out_fh.write(f"         else if ({we_pin})\n")
         out_fh.write("         begin\n")
         out_fh.write(
-            f"            mem[{addr_bus}] <= ({din_bus}) | (mem[{addr_bus}]);\n"
+            f"            mem[{addr_bus}] <= {din_bus};\n"
         )
         out_fh.write("         end\n")
         out_fh.write("         // read\n")


### PR DESCRIPTION
The simulation model for SP memories wasn't describing a functional memory as on a write it was only setting bits, never clearing them. Fix the write statement.

The bitwise OR operation may have been a remnant of a write mask. Before commit 0fb7f8c5 ("Re-factored fakeram to support sp/dp ram/regfile") there was a commented-out line:

    # V_file.write('            mem[addr_in] <= (wd_in & w_mask_in) | (mem[addr_in] & ~w_mask_in);\n')