### PR TITLE
added related pins to rw_port_group

### DIFF
--- a/spreadsheet_ram.py
+++ b/spreadsheet_ram.py
@@ -249,6 +249,11 @@ class SSRAMGenerator:
                     rw_port_group.set_data_output_bus_name(pin_name)
                 elif pin_type == "write_enable":
                     rw_port_group.set_write_enable_name(pin_name)
+                else:
+                    if "msb" in port_data:
+                        rw_port_group.add_related_bus(port_data)
+                    else:
+                        rw_port_group.add_related_pin(pin_name)
             mem.add_rw_port_group(rw_port_group)
         for src in pin_org.get_misc_busses():
             mem.add_misc_bus(src)

--- a/utils/lef_exporter.py
+++ b/utils/lef_exporter.py
@@ -156,6 +156,11 @@ class LefExporter(Exporter):
             if rw_port_group.get_write_enable_name():
                 port = mem.get_port(rw_port_group.get_write_enable_name())
                 self.write_pin(fid, port)
+            for pin_name in rw_port_group.get_related_pins():
+                port = mem.get_port(pin_name)
+                self.write_pin(fid, port)
+            for bus_name, bus_data in rw_port_group.get_related_busses().items():
+                self.write_signal_bus(fid, bus_name, bus_data["lsb"], bus_data["msb"] + 1)
             if rw_port_group.get_clock_name():
                 port = mem.get_port(rw_port_group.get_clock_name())
                 self.write_pin(fid, port)

--- a/utils/liberty_exporter.py
+++ b/utils/liberty_exporter.py
@@ -147,6 +147,14 @@ class LibertyExporter(Exporter):
         addr_bus_msb = mem.get_addr_bus_msb()
         self.write_bus_def(out_fh, name + "_DATA", bits, data_bus_msb)
         self.write_bus_def(out_fh, name + "_ADDRESS", addr_width, addr_bus_msb)
+        for rw_port_group in mem.get_rw_port_groups():
+            for bus_name, bus_data in rw_port_group.get_related_busses().items():
+                self.write_bus_def(
+                    out_fh,
+                    mem.get_name() + "_" + bus_name,
+                    bus_data["msb"] - bus_data["lsb"] + 1,
+                    bus_data["msb"],
+                )
         for bus_name, bus_data in mem.get_misc_busses().items():
             self.write_bus_def(
                 out_fh,
@@ -435,4 +443,8 @@ class LibertyExporter(Exporter):
                 clk_pin_name,
                 is_ram,
             )
+        for related_pin in rw_port_group.get_related_pins():
+            self.write_pin(out_fh, name, related_pin, clk_pin_name)
+        for bus_name,bus_data in rw_port_group.get_related_busses().items():
+            self.write_generic_bus(out_fh, name, bus_name, clk_pin_name)
         self.write_clk_pin(out_fh, clk_pin_name)

--- a/utils/rw_port_group.py
+++ b/utils/rw_port_group.py
@@ -35,6 +35,8 @@ class RWPortGroup:
             self._data_input_bus_name = None
             self._data_output_bus_name = None
             self._clk_name = None
+        self._related_pin_list = []
+        self._related_busses = {}
 
     def set_suffix(self, suffix):
         """
@@ -83,6 +85,22 @@ class RWPortGroup:
     def get_data_output_bus_name(self):
         """Gets the data output bus name"""
         return self._data_output_bus_name
+
+    def add_related_pin(self, name):
+        """Adds related pin"""
+        self._related_pin_list.append(name)
+
+    def get_related_pins(self):
+        """Gets the related pin list"""
+        return self._related_pin_list
+
+    def add_related_bus(self, bus):
+        """Adds related bus"""
+        self._related_busses[bus["name"]] = bus
+
+    def get_related_busses(self):
+        """Gets the related bus dictionary"""
+        return self._related_busses
 
     def _set_names_by_suffix(self, suffix):
         """

--- a/utils/ss_port_organizer.py
+++ b/utils/ss_port_organizer.py
@@ -81,6 +81,11 @@ class SSPortOrganizer:
                     "write_enable",
                     "output_bus",
                     "data_bus",
+                    "toggle_power",
+                    "self_time_bypass",
+                    "mem_enable",
+                    "write_margin_enable",
+                    "write_margin_input",
                 ]:
                     last_char = port_data["name"][-1]
                     self._rw_groups[last_char][port_data["type"]] = port_data

--- a/utils/verilog_exporter.py
+++ b/utils/verilog_exporter.py
@@ -91,6 +91,11 @@ class VerilogExporter(Exporter):
             out_fh.write(f"    {rw_port_group.get_data_output_bus_name()},\n")
         if rw_port_group.get_clock_name():
             out_fh.write(f"    {rw_port_group.get_clock_name()}")
+        for port_name in rw_port_group.get_related_pins():
+            out_fh.write(f"    {port_name}")
+        for bus_name in rw_port_group.get_related_busses():
+            out_fh.write(f"    {bus_name}")
+            
 
     def write_misc_decl_set(self, mem, out_fh):
         """Write the misc bus/port declarations"""
@@ -125,6 +130,15 @@ class VerilogExporter(Exporter):
             out_fh.write(
                 f"    input  wire                     {rw_port_group.get_clock_name()};\n"
             )
+        for pin_name in rw_port_group.get_related_pins():
+            out_fh.write(
+                f"    input  wire                     {pin_name};\n"
+            )
+        for bus_name,bus_data in rw_port_group.get_related_busses().items():
+            out_fh.write(
+                f"    input  wire [{bus_data['msb']}:{bus_data['lsb']}] {bus_name};\n"
+            )
+            
         out_fh.write("\n")
 
     def write_misc_defn_set(self, mem, out_fh):
@@ -170,6 +184,14 @@ class VerilogExporter(Exporter):
         if rw_port_group.get_data_output_bus_name():
             out_fh.write(
                 f"    output reg [{data_bus_msb}:0] {rw_port_group.get_data_output_bus_name()},\n"
+            )
+        for pin_name in rw_port_group.get_related_pins():
+            out_fh.write(
+                f"    input {pin_name},\n"
+            )
+        for bus_name, bus_data in rw_port_group.get_related_busses().items():
+            out_fh.write(
+                f"    input [{bus_data['msb']}:{bus_data['lsb']}] {bus_name},\n"
             )
         if rw_port_group.get_clock_name():
             out_fh.write(f"    input {rw_port_group.get_clock_name()}")


### PR DESCRIPTION
Required to set clock correctly for multi-clock RAMs. Groups related pins in the rw_port_group, so that they can be written out together.
